### PR TITLE
Replace once_cell with std::sync::LazyLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 regex = "1.10"
 clap = { version = "4", features = ["derive"] }
-once_cell = "1.19"
 thiserror = "1.0"
 
 [lib]

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -1,17 +1,18 @@
 //! Pre-compiled regex patterns.
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
+
 use regex::Regex;
 
 /// Matches element reference IDs like [ref=e407]
-pub static REF_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"\[ref=([a-zA-Z0-9-]+)\]").unwrap());
+pub static REF_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\[ref=([a-zA-Z0-9-]+)\]").unwrap());
 
 /// Matches quoted strings after element types
-pub static QUOTE_REGEX: Lazy<Regex> = Lazy::new(|| {
+pub static QUOTE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"(?:button|link|textbox|heading|img|checkbox|radio|menuitem|tab|option|combobox)\s*"([^"]+)""#).unwrap()
 });
 
 /// Matches any quoted string
-pub static SIMPLE_QUOTE_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#""([^"]+)""#).unwrap());
+pub static SIMPLE_QUOTE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#""([^"]+)""#).unwrap());


### PR DESCRIPTION
## Summary

- Replace `once_cell::sync::Lazy` with `std::sync::LazyLock` (stabilized in Rust 1.80)
- Remove `once_cell` dependency from Cargo.toml

## Changes

- `src/regex.rs`: Use `std::sync::LazyLock` for lazy static regex patterns
- `Cargo.toml`: Remove `once_cell = "1.19"`

## Test plan

- [x] All 62 tests pass (`cargo test`)

Closes #5