### PR TITLE
Add --list clickable option and improve summary guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,14 +13,17 @@ Progressive reader for Playwright MCP snapshot JSON files. Parses `.content[0].t
 ### 1. Quick Page Analysis
 
 ```bash
-# Get summary (URL, title, element count)
+# Get summary (URL, title, element count, clickable count)
 # Automatically warns if blank tabs (about:blank) detected
 meyerhold snapshot.json
 
 # Check for errors first
 meyerhold snapshot.json --section errors
 
-# List interactive elements
+# List clickable elements (buttons, links, inputs, tabs - excludes disabled)
+meyerhold snapshot.json --list clickable
+
+# List ALL interactive elements (including disabled)
 meyerhold snapshot.json --list all --format table
 ```
 
@@ -128,9 +131,10 @@ once_cell = "1.19"
 
 | Command | Purpose |
 |---------|---------|
-| `meyerhold FILE` | Summary view |
+| `meyerhold FILE` | Summary view (includes clickable count) |
+| `--list clickable` | Clickable elements only (excludes disabled) |
+| `--list buttons\|links\|inputs\|all` | List elements by type |
 | `--section tabs\|errors\|tree\|page` | Show section |
-| `--list buttons\|links\|inputs\|all` | List elements |
 | `--depth N` | Tree navigation |
 | `--search "pattern"` | Find text |
 | `--search "pattern" --regex` | Regex search |

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -14,6 +14,9 @@ pub enum ListType {
     Images,
     Text,
     All,
+    /// Clickable elements only (buttons, links, inputs, tabs, combobox).
+    /// Excludes elements with [disabled] attribute.
+    Clickable,
 }
 
 /// An interactive element extracted from snapshot.
@@ -27,6 +30,26 @@ pub struct Element {
     pub label: String,
     /// Nesting depth in the tree
     pub depth: usize,
+    /// Whether the element is disabled
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub disabled: bool,
+}
+
+/// Clickable element types (can be interacted with via click).
+const CLICKABLE_TYPES: &[&str] = &[
+    ELEM_BUTTON,
+    ELEM_LINK,
+    ELEM_TEXTBOX,
+    ELEM_CHECKBOX,
+    ELEM_RADIO,
+    ELEM_COMBOBOX,
+    ELEM_SEARCHBOX,
+    ELEM_TAB,
+];
+
+/// Check if line contains [disabled] attribute.
+fn is_disabled(line: &str) -> bool {
+    line.contains("[disabled]")
 }
 
 /// Extract elements of specified type from snapshot text.
@@ -58,9 +81,11 @@ pub fn extract_elements(text: &str, list_type: ListType) -> Vec<Element> {
             ELEM_TAB,
             ELEM_OPTION,
         ],
+        ListType::Clickable => CLICKABLE_TYPES,
     };
 
     let extract_text_only = matches!(list_type, ListType::Text);
+    let filter_disabled = matches!(list_type, ListType::Clickable);
 
     for line in text.lines() {
         let trimmed = line.trim().trim_start_matches("- ");
@@ -80,6 +105,7 @@ pub fn extract_elements(text: &str, list_type: ListType) -> Vec<Element> {
                         element_type: "text".to_string(),
                         label: content,
                         depth: indent / 2,
+                        disabled: false,
                     });
                 }
             }
@@ -92,6 +118,13 @@ pub fn extract_elements(text: &str, list_type: ListType) -> Vec<Element> {
 
         if let Some(&elem_type) = matched_type {
             if let Some(caps) = REF_REGEX.captures(line) {
+                let disabled = is_disabled(line);
+
+                // Skip disabled elements when filtering for clickable
+                if filter_disabled && disabled {
+                    continue;
+                }
+
                 let ref_id = caps.get(1).unwrap().as_str().to_string();
                 let label = extract_label(trimmed);
                 let indent = line.len() - line.trim_start().len();
@@ -102,12 +135,51 @@ pub fn extract_elements(text: &str, list_type: ListType) -> Vec<Element> {
                     element_type: elem_type.to_string(),
                     label,
                     depth,
+                    disabled,
                 });
             }
         }
     }
 
     elements
+}
+
+/// Statistics about clickable elements.
+#[derive(Debug, Clone, Serialize)]
+pub struct ClickableStats {
+    /// Total clickable elements (excluding disabled)
+    pub total: usize,
+    /// Number of disabled elements that would otherwise be clickable
+    pub disabled_count: usize,
+}
+
+/// Count clickable elements in snapshot text.
+pub fn count_clickable(text: &str) -> ClickableStats {
+    let mut total = 0;
+    let mut disabled_count = 0;
+
+    for line in text.lines() {
+        let trimmed = line.trim().trim_start_matches("- ");
+
+        let is_clickable_type = CLICKABLE_TYPES
+            .iter()
+            .any(|&p| trimmed.starts_with(p) || trimmed.starts_with(&format!("'{}", p)));
+
+        if is_clickable_type {
+            if crate::regex::REF_REGEX.captures(line).is_some() {
+                if is_disabled(line) {
+                    disabled_count += 1;
+                } else {
+                    total += 1;
+                }
+            }
+        }
+    }
+
+    ClickableStats {
+        total,
+        disabled_count,
+    }
 }
 
 /// Extract label from element line.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ mod summary;
 mod tree;
 
 // Public re-exports
-pub use elements::{Element, ListType};
+pub use elements::{ClickableStats, Element, ListType};
 pub use error::MeyerholdError;
 pub use search::SearchResult;
 pub use summary::{ContentItem, SnapshotSummary, DEFAULT_TEXT_CHAR_LIMIT};
@@ -186,6 +186,13 @@ impl Meyerhold {
     /// Count blank tabs (about:blank) in the snapshot.
     pub fn blank_tab_count(&self) -> usize {
         summary::count_blank_tabs(&self.snapshot_text)
+    }
+
+    /// Get statistics about clickable elements.
+    ///
+    /// Returns total clickable count and disabled count.
+    pub fn clickable_stats(&self) -> ClickableStats {
+        elements::count_clickable(&self.snapshot_text)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,8 @@ enum CliListType {
     Images,
     Text,
     All,
+    /// Clickable elements only (excludes disabled)
+    Clickable,
 }
 
 impl From<&CliListType> for ListType {
@@ -94,6 +96,7 @@ impl From<&CliListType> for ListType {
             CliListType::Images => ListType::Images,
             CliListType::Text => ListType::Text,
             CliListType::All => ListType::All,
+            CliListType::Clickable => ListType::Clickable,
         }
     }
 }
@@ -216,10 +219,24 @@ fn print_json<T: Serialize>(value: &T) {
 
 fn handle_summary(mh: &Meyerhold, args: &Args) {
     let summary = mh.summary();
+    let clickable = mh.clickable_stats();
 
     match args.format {
         OutputFormat::Json => {
-            print_json(&summary);
+            // Include clickable stats in JSON output
+            let json = serde_json::json!({
+                "page_url": summary.page_url,
+                "page_title": summary.page_title,
+                "tab_count": summary.tab_count,
+                "blank_tab_count": summary.blank_tab_count,
+                "error_count": summary.error_count,
+                "element_count": summary.element_count,
+                "clickable": clickable.total,
+                "clickable_disabled": clickable.disabled_count,
+                "content": summary.content,
+                "content_truncated": summary.content_truncated,
+            });
+            print_json(&json);
         }
         _ => {
             println!("=== Snapshot Summary ===");
@@ -229,14 +246,22 @@ fn handle_summary(mh: &Meyerhold, args: &Args) {
             println!();
             if summary.blank_tab_count > 0 {
                 println!(
-                    "Tabs:     {} ({} blank)",
+                    "Tabs:      {} ({} blank)",
                     summary.tab_count, summary.blank_tab_count
                 );
             } else {
-                println!("Tabs:     {}", summary.tab_count);
+                println!("Tabs:      {}", summary.tab_count);
             }
-            println!("Errors:   {}", summary.error_count);
-            println!("Elements: {}", summary.element_count);
+            println!("Errors:    {}", summary.error_count);
+            println!("Elements:  {}", summary.element_count);
+            if clickable.disabled_count > 0 {
+                println!(
+                    "Clickable: {} ({} disabled excluded)",
+                    clickable.total, clickable.disabled_count
+                );
+            } else {
+                println!("Clickable: {}", clickable.total);
+            }
 
             // Display all content in DOM order
             if !summary.content.is_empty() {
@@ -267,9 +292,9 @@ fn handle_summary(mh: &Meyerhold, args: &Args) {
             }
 
             println!();
-            println!("Use --section <tabs|errors|tree|page> for details");
-            println!("Use --list <buttons|links|inputs|all> for elements");
-            println!("Use --depth N for tree navigation");
+            println!("Next: --list clickable  (show interactive elements)");
+            println!("      --section <tabs|errors|tree|page> for details");
+            println!("      --search \"pattern\" to find specific content");
         }
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -532,3 +532,87 @@ fn test_all_datasets_tree_depth() {
             .stdout(predicate::str::contains("[ref="));
     }
 }
+
+// =============================================================================
+// Clickable Elements Tests
+// =============================================================================
+
+#[test]
+fn test_list_clickable() {
+    let snapshot = get_test_snapshot();
+    meyerhold()
+        .args([snapshot.to_str().unwrap(), "--list", "clickable"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_list_clickable_table_format() {
+    let snapshot = get_test_data("the-internet.json");
+    meyerhold()
+        .args([snapshot.to_str().unwrap(), "--list", "clickable", "--format", "table"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("REF"))
+        .stdout(predicate::str::contains("TYPE"))
+        .stdout(predicate::str::contains("LABEL"));
+}
+
+#[test]
+fn test_list_clickable_json_format() {
+    let snapshot = get_test_data("the-internet.json");
+    meyerhold()
+        .args([snapshot.to_str().unwrap(), "--list", "clickable", "--format", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ref_id"))
+        .stdout(predicate::str::contains("element_type"));
+}
+
+#[test]
+fn test_summary_shows_clickable_count() {
+    let snapshot = get_test_data("the-internet.json");
+    meyerhold()
+        .arg(&snapshot)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Clickable:"));
+}
+
+#[test]
+fn test_summary_json_includes_clickable() {
+    let snapshot = get_test_data("the-internet.json");
+    meyerhold()
+        .args([snapshot.to_str().unwrap(), "--format", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"clickable\""))
+        .stdout(predicate::str::contains("\"clickable_disabled\""));
+}
+
+#[test]
+fn test_summary_shows_next_hint() {
+    let snapshot = get_test_snapshot();
+    meyerhold()
+        .arg(&snapshot)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Next: --list clickable"));
+}
+
+#[test]
+fn test_all_datasets_list_clickable() {
+    let datasets = vec![
+        "todomvc-react.json",
+        "uitestingplayground.json",
+        "the-internet.json",
+    ];
+
+    for dataset in datasets {
+        let snapshot = get_test_data(dataset);
+        meyerhold()
+            .args([snapshot.to_str().unwrap(), "--list", "clickable"])
+            .assert()
+            .success();
+    }
+}


### PR DESCRIPTION
## Summary

- Add `--list clickable` option that shows interactive elements (buttons, links, inputs, tabs) while excluding disabled elements
- Display clickable count in summary view with disabled exclusion note
- Improve hint text to guide users toward `--list clickable` as the natural next step

## Changes

### New Features
- `ListType::Clickable` includes: button, link, textbox, checkbox, radio, combobox, searchbox, tab
- Elements with `[disabled]` attribute are automatically excluded
- Summary now shows: `Clickable: 110 (2 disabled excluded)`
- JSON output includes `clickable` and `clickable_disabled` fields

### Implementation
- Added `ClickableStats` struct and `clickable_stats()` method to library API
- Added `is_disabled()` helper to detect `[disabled]` attribute in Playwright snapshots
- Updated hint text: `Next: --list clickable (show interactive elements)`

## Test plan

- [x] `cargo test` - 51 integration tests pass (7 new for clickable)
- [x] `cargo build --release` - compiles without warnings
- [x] Manual testing with real Playwright MCP snapshots
- [x] Verified disabled elements are correctly excluded

Closes #9