### PR TITLE
Fix blank text filtering in content output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meyerhold"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Yoshifumi Nakahira"]
 description = "Progressive reader for Playwright MCP snapshot JSON files"

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -132,12 +132,14 @@ pub fn parse_summary_with_limit(text: &str, char_limit: usize) -> SnapshotSummar
                 .trim()
                 .trim_matches('"')
                 .to_string();
-            if !label.is_empty() {
-                // text: elements typically don't have ref
-                let ref_id = LINE_REF_REGEX
-                    .captures(line)
-                    .and_then(|c| c.get(1).map(|m| m.as_str().to_string()))
-                    .unwrap_or_default();
+            let ref_id = LINE_REF_REGEX
+                .captures(line)
+                .and_then(|c| c.get(1).map(|m| m.as_str().to_string()))
+                .unwrap_or_default();
+            // Check if label has meaningful content (at least one alphanumeric char)
+            let has_content = label.chars().any(|c| c.is_alphanumeric());
+            // Skip only if BOTH blank AND no ref
+            if has_content || !ref_id.is_empty() {
                 let label_len = label.chars().count();
                 if total_chars + label_len <= char_limit {
                     total_chars += label_len;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -195,7 +195,10 @@ fn extract_content_item(line: &str) -> Option<ContentItem> {
     // Text element
     else if trimmed.starts_with("text:") {
         let label = trimmed.trim_start_matches("text:").trim().trim_matches('"');
-        if !label.is_empty() {
+        // Check if label has meaningful content (at least one alphanumeric char)
+        let has_content = label.chars().any(|c| c.is_alphanumeric());
+        // Skip only if BOTH blank AND no ref
+        if has_content || !ref_id.is_empty() {
             return Some(ContentItem::Text {
                 ref_id,
                 label: label.to_string(),


### PR DESCRIPTION
## Summary
- Skip text elements that have both empty content (no alphanumeric chars) AND no ref
- Text with content or with ref is still included
- Fixes issue where "text: :" entries without refs polluted output

## Test plan
- [x] All tests pass
- [x] Verified with actual snapshot